### PR TITLE
Feature/timeoutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
     - constant: Limits, or not, all calls received
     - probabilistic: Limits the number of calls to a ratio of accepted/refused calls
     - ratelimiting: Limits the number of calls to a fixed rate per second
+- Added `@timeoutable`, stopping the execution of a callable if its run time is too long

--- a/flashback/__init__.py
+++ b/flashback/__init__.py
@@ -5,6 +5,7 @@ from .deprecated import deprecated
 from .retryable import retryable
 from .sampled import sampled
 from .timeable import timeable
+from .timeoutable import timeoutable
 
 
 __all__ = (
@@ -13,7 +14,8 @@ __all__ = (
     'deprecated',
     'retryable',
     'sampled',
-    'timeable'
+    'timeable',
+    'timeoutable',
 )
 
 __version__ = '1.0.0'

--- a/flashback/timeoutable.py
+++ b/flashback/timeoutable.py
@@ -1,0 +1,59 @@
+import functools
+import signal
+
+
+def timeoutable(seconds=5, message='execution timed out'):
+    """
+    Times out a callable's execution if its runtime exceeds `seconds`.
+
+    Examples:
+        ```python
+        import time
+        from flashback import timeoutable
+
+        @timeoutable(1)
+        def fast():
+            time.sleep(0.1)
+
+            return True
+
+        fast()
+        #=> True
+
+        @timeoutable(1)
+        def slow():
+            time.sleep(3)
+
+            return True
+
+        slow()
+        #=> TimeoutError: Execution of slow timed out.
+        ```
+
+    Params:
+        - `seconds (int)` the number of seconds to wait before timing out
+        - `message (str)` the custom message to display when timing out
+
+    Return:
+        - `Callable` a wrapper used to decorate a callable
+
+    Raises:
+        - `TimeoutError` if the callable's execution time is longer than `seconds`
+    """
+    def wrapper(func):
+        def _sigalrm_handler(_signum, _frame):
+            raise TimeoutError(message)
+
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            signal.signal(signal.SIGALRM, _sigalrm_handler)
+            signal.alarm(seconds)
+
+            try:
+                return func(*args, **kwargs)
+            finally:
+                signal.alarm(0)
+
+        return inner
+
+    return wrapper

--- a/tests/test_timeoutable.py
+++ b/tests/test_timeoutable.py
@@ -1,0 +1,39 @@
+# pylint: disable=no-self-use,no-member,protected-access
+
+import time
+
+import pytest
+from mock import Mock
+
+from flashback import timeoutable
+
+
+def dummy_func(spy):
+    time.sleep(2)
+    spy.__call__()
+
+
+class TestTimeoutable:
+    def test_timeoutable(self):
+        make_timeoutable = timeoutable(1)
+        decorated_func = make_timeoutable(dummy_func)
+
+        with pytest.raises(TimeoutError) as e:
+            decorated_func(None)
+            assert e.message == 'execution timed out'
+
+    def test_timeoutable_without_timeout(self):
+        spy_func = Mock()
+        make_timeoutable = timeoutable(3)
+        decorated_func = make_timeoutable(dummy_func)
+
+        decorated_func(spy_func)
+
+        assert spy_func.called
+
+    def test_timeoutable_with_message(self):
+        make_timeoutable = timeoutable(1, message='dummy_func timed out')
+        decorated_func = make_timeoutable(dummy_func)
+        with pytest.raises(TimeoutError) as e:
+            decorated_func(None)
+            assert e.message == 'dummy_func timed out'


### PR DESCRIPTION
### Description

- Added `@timeoutable`, a decorator to make a callable's execution time out if its run time is too long
- Closes #20 

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [ ] Version has been updated
