### PR TITLE
Feature/partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added the `iterating/` module, containing several helpers for iterables:
     - `renumerate()` enumerates an iterable starting from its end
     - `chunks()` splits an iterable into smalled chunks, padding them if requested
+    - `partition()` splits an iterable into the items that validated the given predicate and the others
 - Added the `i16g/` module, to help with locale management:
     - A helper class to dynamically load localization files from a package path
 - Added the `importing/` module, a collection of helpers for dynamic importing:

--- a/flashback/iterating/__init__.py
+++ b/flashback/iterating/__init__.py
@@ -1,8 +1,10 @@
 from .functions import chunks
 from .functions import renumerate
+from .functions import partition
 
 
 __all__ = (
     'chunks',
     'renumerate',
+    'partition',
 )

--- a/flashback/iterating/functions.py
+++ b/flashback/iterating/functions.py
@@ -61,3 +61,37 @@ def chunks(iterable, size=2, pad=Sentinel):
                 chunk += (pad,) * len_diff
 
             yield chunk
+
+def partition(predicate, iterable):
+    """
+    Splits an `iterable` into two lists containing items that validate or not the given `predicate`.
+
+    Items that validated the predicate are first in the returned tuple.
+
+    Examples:
+        ```python
+        from flashback.iterating import partitions
+
+        evens, odds = partition(lambda x: x % 2, [1, 2, 3, 4, 5])
+
+        assert evens == [2, 4]
+        assert odds == [1, 3, 5]
+        ```
+
+    Params:
+        - `predicate (lambda)` the lambda to apply on each item of `iterable`
+        - `iterable (Iterable)` the iterable to partition
+
+    Returns:
+        - `tuple<list>` the iterable's items separated depending on `predicate`
+    """
+    trues = []
+    falses = []
+
+    for item in iterable:
+        if predicate(item):
+            trues.append(item)
+        else:
+            falses.append(item)
+
+    return (trues, falses)

--- a/tests/iterating/test_functions.py
+++ b/tests/iterating/test_functions.py
@@ -41,3 +41,29 @@ class TestChunks:
     def test_multiple_pad_items_with_pad(self):
         chunked = list(chunks([None, None, None], pad=None))
         assert chunked == [[None, None], [None, None]]
+
+
+class TestPartition:
+    def test_zero_items(self):
+        trues, falses = partition(lambda x: x % 2, [])
+
+        assert trues == []
+        assert falses == []
+
+    def test_multiple_items_bool(self):
+        evens, odds = partition(lambda x: x % 2 == 0, [1, 2, 3, 4, 5])
+
+        assert evens == [2, 4]
+        assert odds == [1, 3, 5]
+
+    def test_multiple_items_str(self):
+        trues, falses = partition(lambda x: x if 'a' in x else None, ['a', 'b', 'c', 'd', 'aa'])
+
+        assert trues == ['a', 'aa']
+        assert falses == ['b', 'c', 'd']
+
+    def test_multiple_items_list(self):
+        trues, falses = partition(lambda x: x, [['a'], [], [1], ['b'], [2], []])
+
+        assert trues == [['a'], [1], ['b'], [2]]
+        assert falses == [[], []]


### PR DESCRIPTION
### Description

- Added `iterating/partition()`, a helper to split iterables in two buckets: one with items that validated the predicate and one containing those that didn't
- Closes #35

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md has been updated
