### PR TITLE
Debugging/profiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - A decorator `@cached`, that caches a callable's return value based on its arguments
 - Added the `debugging/` module:
     - A helper function `xp`, to print debugging statements
+    - A decorator `@profiled`, to collect and dumps profiling stats over a callable's execution
 - Added the `formatting/` module, a collection of helper functions:
     - `oxford_join()` joins strings in a human-readable way
     - `transliterate()` represents unicode text in ASCII (using [Unidecode](https://github.com/avian2/unidecode))

--- a/flashback/debugging/__init__.py
+++ b/flashback/debugging/__init__.py
@@ -1,5 +1,8 @@
+from .profiled import profiled
 from .xp import xp
 
+
 __all__ = (
+    'profiled',
     'xp',
 )

--- a/flashback/debugging/profiled.py
+++ b/flashback/debugging/profiled.py
@@ -1,0 +1,72 @@
+import cProfile
+import functools
+
+
+def profiled(output=None):
+    """
+    Profiles a call made to a callable and dump the stats to a file for further analysis.
+
+    By default, prints the stats to a file f"{func.__name__}.pstats".
+
+    The file in which the stats are dumped will be located in the folder from where it has been called.
+
+    To visualize the stats collected during profiling, you can use:
+        - snakeviz:
+            ```bash
+            pip install snakeviz
+            snakeviz *.pstats
+            ```
+        - gprof2dot:
+            ```bash
+            brew/apt-get/yum/pacman install graphviz
+            pip install gprof2dot
+            gprof2dot -f pstats *.pstats | dot -Tpng -o heatgraph.png
+            ```
+
+    Examples:
+        ```python
+        from flashback.debugging import profiled
+
+        @profiled()
+        def fibonnaci(n):
+            if n == 0:
+                return 0
+            elif n == 1:
+                return 1
+            else:
+                return fibonacci(n - 1) + fibonacci(n - 2)
+
+        fib(10)
+        #=> Writes 'fib.pstats'
+
+        @profiled('profiled')
+        def cached_fibonacci(n, _cache={}):
+            if n in _cache:
+                return _cache[n]
+            elif n > 1:
+                return _cache.setdefault(n, cached_fibonacci(n - 1) + cached_fibonacci(n - 2))
+            return n
+
+        fib(10)
+        #=> Writes 'profiled.pstats'
+        ```
+
+    Params:
+        - `output (str)` the output to write the stats to
+
+    Returns:
+        - `Callable` a wrapper used to decorate a callable
+    """
+    def wrapper(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            profiler = cProfile.Profile()
+
+            result = profiler.runcall(func, *args, **kwargs)
+
+            profiler.dump_stats(output or f"{func.__name__}.pstats")
+
+            return result
+
+        return inner
+    return wrapper

--- a/tests/debugging/test_profiled.py
+++ b/tests/debugging/test_profiled.py
@@ -1,0 +1,40 @@
+# pylint: disable=no-self-use
+
+import os
+
+from flashback.debugging import profiled
+
+
+def dummy_func(left, right):
+    return left > right
+
+
+class TestProfiled:
+    def test_profiled(self):
+        output_name = 'dummy_func.pstats'
+        make_profiled = profiled()
+        decorated_func = make_profiled(dummy_func)
+
+        decorated_func(1, 2)
+
+        self.assert_output_valid(output_name)
+
+
+    def test_profiled_with_name(self):
+        output_name = 'output.cprofile'
+        make_profiled = profiled(output_name)
+        decorated_func = make_profiled(dummy_func)
+
+        decorated_func(1, 2)
+
+        self.assert_output_valid(output_name)
+
+    @staticmethod
+    def assert_output_valid(output_name):
+        output_filename = os.path.join(os.getcwd(), output_name)
+        try:
+            output = open(output_filename, 'rb').read()
+
+            assert output != ''
+        finally:
+            os.remove(output_filename)


### PR DESCRIPTION
### Description

- Added @profiled, a decorator dumping cProfile stats gathered during the decorated callable's execution
- Closes #34 

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md has been updated
