### PR TITLE
Feature/get_frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
     - A wrapper supporting several cache stores: in-memory, disk, Redis, and Memcached
     - A decorator `@cached`, that caches a callable's return value based on its arguments
 - Added the `debugging/` module:
-    - A helper function `xp`, to print debugging statements
+    - A helper function `xp()`, to print debugging statements
     - A decorator `@profiled`, to collect and dumps profiling stats over a callable's execution
+    - A helper `get_frame()`, which implements a faster `inspect.stack()[x]`
 - Added the `formatting/` module, a collection of helper functions:
     - `oxford_join()` joins strings in a human-readable way
     - `transliterate()` represents unicode text in ASCII (using [Unidecode](https://github.com/avian2/unidecode))

--- a/flashback/debugging/__init__.py
+++ b/flashback/debugging/__init__.py
@@ -1,8 +1,10 @@
+from .get_frame import get_frame
 from .profiled import profiled
 from .xp import xp
 
 
 __all__ = (
+    'get_frame',
     'profiled',
     'xp',
 )

--- a/flashback/debugging/get_frame.py
+++ b/flashback/debugging/get_frame.py
@@ -1,0 +1,38 @@
+import inspect
+
+
+def get_frame(depth=0, context=1):
+    """
+    Finds the frame at `depth` and builds a FrameInfo from it.
+
+    Executes 10 times faster than `inspect.stack()[depth]` if depth is
+    superior to 1, else only 2 times.
+
+    Handles negative `depth` by returning the current frame from the
+    caller's perspective, just like `sys._getframe()` does.
+
+    Params:
+        - `depth (int)` the depth at which to find the frame
+        - `context (int)` the number of lines surrounding the frame to use in the traceback of the frame
+
+    Returns:
+        - `inspect.FrameInfo`: the FrameInfo object for the frame
+
+    Raises:
+        - `ValueError` if `depth` is greater than the length of the call stack
+    """
+    # Could use `sys._getframe(1)` but safer to go through its wrapper
+    frame = inspect.currentframe()
+    # We need to skip the actual current frame (the execution of get_frame())
+    depth = depth + 1 if depth > -1 else 1
+    for _ in range(depth):
+        if frame is None:
+            raise ValueError('call stack is not deep enough')
+
+        frame = frame.f_back
+
+    if frame is None:
+        raise ValueError('call stack is not deep enough')
+
+    frameinfo = (frame,) + inspect.getframeinfo(frame, context)
+    return inspect.FrameInfo(*frameinfo)

--- a/flashback/debugging/parser.py
+++ b/flashback/debugging/parser.py
@@ -5,6 +5,8 @@ from textwrap import dedent
 
 import regex
 
+from .get_frame import get_frame
+
 
 class Parser:
     """
@@ -64,7 +66,7 @@ class Parser:
         try:
             # We access [2] because an end-user call to xp() calls this code (thus, two layers of calls)
             # If this code would have been called directly by the end-user, we would need to access [1]
-            calling_frame = inspect.stack()[self._offset]
+            calling_frame = get_frame(self._offset)
 
             filename = os.path.relpath(calling_frame.filename)
 

--- a/tests/debugging/test_get_frame.py
+++ b/tests/debugging/test_get_frame.py
@@ -1,0 +1,43 @@
+# pylint: disable=no-self-use,redefined-outer-name
+
+import pytest
+from mock import patch
+
+from flashback.debugging import get_frame
+
+
+class TestGetFrame:
+    def test_current(self):
+        frameinfo = get_frame()
+
+        assert frameinfo.function == 'test_current'
+
+    def test_previous(self):
+        def dummy_func(depth):
+            return get_frame(depth)
+
+        frameinfo = dummy_func(1)
+
+        assert frameinfo.function == 'test_previous'
+
+    def test_future(self):
+        frameinfo = get_frame(-1)
+
+        assert frameinfo.function == 'test_future'
+
+    def test_deep(self):
+        frameinfo = get_frame(6)
+
+        assert frameinfo.function == 'runtest'
+
+    @patch('inspect.currentframe')
+    def test_no_current_frame(self, mocked_currentframe):
+        mocked_currentframe.side_effect = [None]
+        with pytest.raises(ValueError):
+            get_frame(1)
+
+    def test_no_last_frame(self):
+        # TODO: remove magic index
+        # How to make sure that the last call to frame.f_back returns None?
+        with pytest.raises(ValueError):
+            get_frame(36)

--- a/tests/debugging/test_parser.py
+++ b/tests/debugging/test_parser.py
@@ -47,18 +47,18 @@ class TestParser:
         assert parsed_arguments == [(None, None)]
         assert warning == 'error parsing code, no code context found'
 
-    @patch('inspect.stack')
-    def test_parse_exception(self, mocked_inspect_stack, parser):
+    @patch('flashback.debugging.parser.get_frame')
+    def test_parse_exception(self, mocked_get_frame, parser):
         xp = parser.parse
 
-        mocked_inspect_stack.side_effect = TypeError('object is not a frame or traceback object')
+        mocked_get_frame.side_effect = ValueError('call stack is not deep enough')
 
         filename, lineno, parsed_arguments, warning = xp(None)
 
         assert filename == '<unknown>'
         assert lineno == 0
         assert parsed_arguments == [(None, None)]
-        assert warning == 'error parsing code, object is not a frame or traceback object (TypeError)'
+        assert warning == 'error parsing code, call stack is not deep enough (ValueError)'
 
     def test_parse_simple(self, parser):
         xp = parser.parse


### PR DESCRIPTION
### Description

- Added `debugging/get_frame()`, a faster implementation of `inspect.stack()[x]`
- Used `get_frame` in `debugging/Parser`
- Closes #46 

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md is up to date
