### PR TITLE
feat(iterating) add compact to remove None values from an iterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     - `chunks()` splits an iterable into smalled chunks, padding them if requested
     - `partition()` splits an iterable into the items that validated the given predicate and the others
     - `uniq()` removes duplicates from an iterable while keeping the items' order
+    - `compact()` removes None values from an iterable
 - Added the `i16g/` module, to help with locale management:
     - A helper class `Locale`, to dynamically load localization files from a package path
 - Added the `importing/` module, a collection of helpers for dynamic importing:

--- a/flashback/iterating/__init__.py
+++ b/flashback/iterating/__init__.py
@@ -1,4 +1,5 @@
 from .chunks import chunks
+from .compact import compact
 from .partition import partition
 from .renumerate import renumerate
 from .uniq import uniq
@@ -6,6 +7,7 @@ from .uniq import uniq
 
 __all__ = (
     'chunks',
+    'compact',
     'partition',
     'renumerate',
     'uniq',

--- a/flashback/iterating/compact.py
+++ b/flashback/iterating/compact.py
@@ -1,0 +1,11 @@
+def compact(iterable):
+    """
+    Removes None items from `iterable`.
+
+    Params:
+        - `iterable (Iterable<Any>)` the iterable to remove None from
+
+    Returns:
+        - `tuple<Any>` the iterable without duplicates
+    """
+    return tuple(item for item in iterable if item is not None)

--- a/tests/iterating/test_compact.py
+++ b/tests/iterating/test_compact.py
@@ -1,0 +1,20 @@
+# pylint: disable=no-self-use
+
+from flashback.iterating import compact
+
+
+class TestCompact:
+    def test_zero_items(self):
+        compacted = compact([])
+
+        assert compacted == ()
+
+    def test_multiple_items(self):
+        compacted = compact([1, None, 2, 3, None, 4, 5, None])
+
+        assert compacted == (1, 2, 3, 4, 5)
+
+    def test_only_none(self):
+        compacted = compact([None, None, None])
+
+        assert compacted == ()


### PR DESCRIPTION
### Description

- Added `iterating/compact` to remove None values from an iterable
- Closes #42 

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md is up to date
