### PR TITLE
doc(iterating) add missing examples

### DIFF
--- a/flashback/iterating/compact.py
+++ b/flashback/iterating/compact.py
@@ -2,6 +2,18 @@ def compact(iterable):
     """
     Removes None items from `iterable`.
 
+    Examples:
+        ```python
+        from flashback.iterating import compact
+
+        for user_id in compact([1058, None, 85, 9264, 19475, None]):
+            print(user_id)
+        #=> 1058
+        #=> 85
+        #=> 9264
+        #=> 19475
+        ```
+
     Params:
         - `iterable (Iterable<Any>)` the iterable to remove None from
 

--- a/flashback/iterating/uniq.py
+++ b/flashback/iterating/uniq.py
@@ -1,6 +1,21 @@
 def uniq(iterable):
     """
-    Removes duplicates items from `iterable` while respecting their apparition order.
+    Removes duplicates items from `iterable` while keeping their order.
+
+    Examples:
+        ```python
+        from flashback.iterating import uniq
+
+        for user_id in uniq([1058, 1058, 85, 9264, 19475, 85]):
+            print(user_id)
+        #=> 1058
+        #=> 85
+        #=> 9264
+        #=> 19475
+
+        # Keeps order
+        assert set([1, 1, 3, 4, 5, 5]) != uniq([1, 1, 3, 4, 5, 5])
+        ```
 
     Params:
         - `iterable (Iterable<Any>)` the iterable to remove duplicates from


### PR DESCRIPTION
### Description

- Added missing documentation for `iterating/uniq()` and `iterating/compact()`

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md is up to date
