### PR TITLE
Feature/cache ttl

### DIFF
--- a/flashback/caching/adapters/base.py
+++ b/flashback/caching/adapters/base.py
@@ -18,13 +18,14 @@ class BaseAdapter(ABC):
         """
 
     @abstractmethod
-    def set(self, key, value):
+    def set(self, key, value, ttl):
         """
         Caches a `value` under a given `key`.
 
         Params:
             - `key (str)` the key under which to cache the value
             - `value (str)` the value to cache
+            - `ttl (int)` the number of seconds before expiring the key
 
         Returns:
             - `bool` whether or not the operation succeeded
@@ -34,13 +35,14 @@ class BaseAdapter(ABC):
         """
 
     @abstractmethod
-    def batch_set(self, keys, values):
+    def batch_set(self, keys, values, ttls):
         """
         Caches each value from a list of `values` to its respective key in a list of `keys`.
 
         Params:
             - `keys (Iterable<str>)` the keys under which to cache the values
             - `values (Iterable<str>)` the values to cache
+            - `ttls (Iterable<int>)` the number of seconds before expiring the keys
 
         Returns:
             - `bool` whether or not the operation succeeded

--- a/flashback/caching/adapters/disk_adapter.py
+++ b/flashback/caching/adapters/disk_adapter.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from datetime import datetime, timedelta
 from fcntl import flock, LOCK_SH, LOCK_EX, LOCK_UN
 import shelve
 import tempfile
@@ -19,37 +20,57 @@ class DiskAdapter(BaseAdapter):
 
         self._store_path = f"{tempfile.gettempdir()}/{uuid.uuid4()}"
 
-    def set(self, key, value):
+    def set(self, key, value, ttl):
+        if ttl == -1:
+            expiry = None
+        else:
+            expiry = datetime.timestamp(datetime.now() + timedelta(seconds=ttl))
+
         with self._open_locked_store(LOCK_EX) as store:
-            store[key] = value
+            store[key] = (value, expiry)
 
         return True
 
-    def batch_set(self, keys, values):
+    def batch_set(self, keys, values, ttls):
+        now = datetime.now()
+        expiries = [None if ttl == -1 else datetime.timestamp(now + timedelta(seconds=ttl)) for ttl in ttls]
+
+        values = zip(values, expiries)
+
         with self._open_locked_store(LOCK_EX) as store:
             store.update(dict(zip(keys, values)))
 
         return True
 
     def get(self, key):
+        self._evict()
+
         with self._open_locked_store(LOCK_SH) as store:
-            return store.get(key, None)
+            return store.get(key, (None,))[0]
 
     def batch_get(self, keys):
+        self._evict()
+
         with self._open_locked_store(LOCK_SH) as store:
-            return [store.get(key, None) for key in keys]
+            return [store.get(key, (None,))[0] for key in keys]
 
     def delete(self, key):
+        self._evict()
+
         with self._open_locked_store(LOCK_EX) as store:
             return bool(store.pop(key, False))
 
     def batch_delete(self, keys):
+        self._evict()
+
         with self._open_locked_store(LOCK_EX) as store:
             res = [bool(store.pop(key, False)) for key in keys]
 
         return False not in res
 
     def exists(self, key):
+        self._evict()
+
         with self._open_locked_store(LOCK_SH) as store:
             return key in store
 
@@ -76,3 +97,16 @@ class DiskAdapter(BaseAdapter):
                     yield store
             finally:
                 flock(lock.fileno(), LOCK_UN)
+
+    def _evict(self):
+        now = datetime.timestamp(datetime.now())
+
+        expired_keys = set()
+
+        with self._open_locked_store(LOCK_EX) as store:
+            for key, (_, expiry) in store.items():
+                if expiry is not None and expiry < now:
+                    expired_keys.add(key)
+
+            for expired_key in expired_keys:
+                del store[expired_key]

--- a/flashback/caching/adapters/memcached_adapter.py
+++ b/flashback/caching/adapters/memcached_adapter.py
@@ -30,7 +30,7 @@ class MemcachedAdapter(BaseAdapter):
 
         ttls = [0 if ttl == -1 else ttl for ttl in ttls]
         for key, value, ttl in zip(keys, values, ttls):
-            ttl = self.store._check_integer(ttl, 'expire')
+            ttl = self.store._check_integer(ttl, 'expire')  # pylint: disable=protected-access
             key = self.store.check_key(key)
             value, flags = self.store.serde.serialize(key, value)
 
@@ -41,7 +41,7 @@ class MemcachedAdapter(BaseAdapter):
             command += value.encode(self.store.encoding) + b'\r\n'
             commands.append(command)
 
-        results = self.store._misc_cmd(commands, 'set', False)
+        results = self.store._misc_cmd(commands, 'set', False)  # pylint: disable=protected-access
 
         for line in results:
             if line == b'NOT_STORED':
@@ -73,7 +73,7 @@ class MemcachedAdapter(BaseAdapter):
             command = b'delete ' + key +  b'\r\n'
             commands.append(command)
 
-        results = self.store._misc_cmd(commands, 'delete', False)
+        results = self.store._misc_cmd(commands, 'delete', False)  # pylint: disable=protected-access
 
         for line in results:
             print(f"\"{line}\"")

--- a/flashback/caching/adapters/memcached_adapter.py
+++ b/flashback/caching/adapters/memcached_adapter.py
@@ -16,13 +16,38 @@ class MemcachedAdapter(BaseAdapter):
 
         self.store = Client((host, port), **kwargs)
 
-    def set(self, key, value):
-        return self.store.set(key, value)
+    def set(self, key, value, ttl):
+        if ttl == -1:
+            ttl = 0
 
-    def batch_set(self, keys, values):
-        # pymemcache returns a list of the keys that failed to be inserted,
-        # we convert that to a boolean
-        return not bool(self.store.set_multi(dict(zip(keys, values))))
+        return self.store.set(key, value, expire=ttl)
+
+    def batch_set(self, keys, values, ttls):
+        # There's two reasons to recode pymemcache.set_multi():
+        # - It returns a list of keys that failed to be inserted, and the base expects a boolean
+        # - It only allows a unique ttl for all keys
+        commands = []
+
+        ttls = [0 if ttl == -1 else ttl for ttl in ttls]
+        for key, value, ttl in zip(keys, values, ttls):
+            ttl = self.store._check_integer(ttl, 'expire')
+            key = self.store.check_key(key)
+            value, flags = self.store.serde.serialize(key, value)
+
+            command = b'set ' + key
+            command += b' ' + str(flags).encode(self.store.encoding)
+            command += b' ' + ttl
+            command += b' ' + str(len(value)).encode(self.store.encoding) + b'\r\n'
+            command += value.encode(self.store.encoding) + b'\r\n'
+            commands.append(command)
+
+        results = self.store._misc_cmd(commands, 'set', False)
+
+        for line in results:
+            if line == b'NOT_STORED':
+                return False
+
+        return True
 
     def get(self, key):
         value = self.store.get(key)
@@ -39,8 +64,23 @@ class MemcachedAdapter(BaseAdapter):
         return self.store.delete(key, noreply=False)
 
     def batch_delete(self, keys):
-        # We do not use `pymemcache`'s `delete_multi` since it always return True
-        return False not in [self.store.delete(key, noreply=False) for key in keys]
+        # Here as well, pymemcache.delete_multi() always returns True
+        commands = []
+
+        for key in keys:
+            key = self.store.check_key(key)
+
+            command = b'delete ' + key +  b'\r\n'
+            commands.append(command)
+
+        results = self.store._misc_cmd(commands, 'delete', False)
+
+        for line in results:
+            print(f"\"{line}\"")
+            if line == b'NOT_FOUND':
+                return False
+
+        return True
 
     def exists(self, key):
         # Can't just cast to bool since we can store falsey values

--- a/flashback/caching/adapters/memory_adapter.py
+++ b/flashback/caching/adapters/memory_adapter.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta
+from threading import RLock
+
 from .base import BaseAdapter
 
 
@@ -9,33 +12,60 @@ class MemoryAdapter(BaseAdapter):
     def __init__(self, **kwargs):
         super().__init__()
 
+        self._lock = RLock()
         self.store = {}
 
-    def set(self, key, value):
-        self.store[key] = value
+    def set(self, key, value, ttl):
+        if ttl == -1:
+            expiry = None
+        else:
+            expiry = datetime.timestamp(datetime.now() + timedelta(seconds=ttl))
+
+        with self._lock:
+            self.store[key] = (value, expiry)
 
         return True
 
-    def batch_set(self, keys, values):
-        self.store.update(dict(zip(keys, values)))
+    def batch_set(self, keys, values, ttls):
+        now = datetime.now()
+        expiries = [None if ttl == -1 else datetime.timestamp(now + timedelta(seconds=ttl)) for ttl in ttls]
+
+        values = zip(values, expiries)
+
+        with self._lock:
+            self.store.update(dict(zip(keys, values)))
 
         return True
 
     def get(self, key):
-        return self.store.get(key, None)
+        self._evict()
+
+        return self.store.get(key, (None,))[0]
 
     def batch_get(self, keys):
-        return [self.store.get(key, None) for key in keys]
+        self._evict()
+
+        return [self.store.get(key, (None,))[0] for key in keys]
 
     def delete(self, key):
-        return bool(self.store.pop(key, False))
+        self._evict()
+
+        with self._lock:
+            value = self.store.pop(key, False)
+
+        return bool(value)
 
     def batch_delete(self, keys):
-        res = [bool(self.store.pop(key, False)) for key in keys]
+        self._evict()
+
+        with self._lock:
+            res = [bool(self.store.pop(key, False)) for key in keys]
 
         return False not in res
 
     def exists(self, key):
+        self._evict()
+
         return key in self.store
 
     def flush(self):
@@ -49,3 +79,16 @@ class MemoryAdapter(BaseAdapter):
     @property
     def connection_exceptions(self):
         return ()
+
+    def _evict(self):
+        now = datetime.timestamp(datetime.now())
+
+        expired_keys = set()
+
+        for key, (_, expiry) in self.store.items():
+            if expiry is not None and expiry < now:
+                expired_keys.add(key)
+
+        with self._lock:
+            for expired_key in expired_keys:
+                del self.store[expired_key]

--- a/flashback/caching/adapters/redis_adapter.py
+++ b/flashback/caching/adapters/redis_adapter.py
@@ -23,11 +23,23 @@ class RedisAdapter(BaseAdapter):
         self._encoding = encoding
         self.store = Redis(host=host, port=port, db=db, encoding=encoding, **kwargs)
 
-    def set(self, key, value):
-        return self.store.set(key, value)
+    def set(self, key, value, ttl):
+        if ttl == -1:
+            ttl = None
 
-    def batch_set(self, keys, values):
-        return self.store.mset(dict(zip(keys, values)))
+        return self.store.set(key, value, ex=ttl)
+
+    def batch_set(self, keys, values, ttls):
+        ttls = [None if ttl == -1 else ttl for ttl in ttls]
+
+        pipe = self.store.pipeline()
+
+        pipe.mset(dict(zip(keys, values)))
+        for key, ttl in zip(keys, ttls):
+            if ttl is not None:
+                pipe.expire(key, ttl)
+
+        return pipe.execute()
 
     def get(self, key):
         value = self.store.get(key)

--- a/flashback/caching/cache.py
+++ b/flashback/caching/cache.py
@@ -119,7 +119,7 @@ class Cache:
         if ttls is None:
             ttls = [-1 for _ in range(len(keys))]
 
-        if len(set(map(len, keys, values, ttls))) > 1:
+        if len(set(map(len, [keys, values, ttls]))) > 1:
             raise ValueError("invalid arguments, length of 'keys', 'values', and 'ttls' must be equal")
 
         json_values = [json.dumps(self._convert_numeric(value)) for value in values]

--- a/tests/caching/adapters/test_disk_adapter.py
+++ b/tests/caching/adapters/test_disk_adapter.py
@@ -1,5 +1,7 @@
 # pylint: disable=no-self-use,redefined-outer-name
 
+import time
+
 import pytest
 
 from flashback.caching.adapters import DiskAdapter
@@ -12,76 +14,83 @@ def adapter():
 
 class TestDiskAdapter:
     def test_set(self, adapter):
-        assert adapter.set('a', 1)
+        assert adapter.set('a', '1', -1)
 
     def test_batch_set(self, adapter):
-        assert adapter.batch_set(['a', 'b', 'c'], [1, 2, 3])
+        assert adapter.batch_set(['a', 'b', 'c'], ['1', '2', '3'], [-1, -1, -1])
 
     def test_get(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         item = adapter.get('a')
 
-        assert item == 1
+        assert item == '1'
 
-    def test_get_empty(self, adapter):
-        item = adapter.get('z')
+    def test_get_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        item = adapter.get('a')
 
         assert item is None
 
     def test_batch_get(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [1, 2]
+        assert items == ['1', '2']
 
-    def test_batch_get_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_get_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        items = adapter.batch_get(['a', 'z'])
+        time.sleep(1)
 
-        assert len(items) == 2
-        assert items == [1, None]
-
-    def test_batch_get_empty(self, adapter):
-        items = adapter.batch_get(['a', 'z'])
+        items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [None, None]
+        assert items == ['1', None]
 
     def test_delete(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.delete('a')
 
-    def test_delete_empty(self, adapter):
-        assert not adapter.delete('z')
+    def test_delete_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert not adapter.delete('a')
 
     def test_batch_delete(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         assert adapter.batch_delete(['a', 'b'])
 
-    def test_batch_delete_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_delete_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        assert not adapter.batch_delete(['a', 'z'])
+        time.sleep(1)
 
-    def test_batch_delete_empty(self, adapter):
         assert not adapter.batch_delete(['a', 'b'])
 
     def test_exists(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.exists('a')
 
-    def test_exists_empty(self, adapter):
-        assert not adapter.exists('z')
+    def test_exists_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert not adapter.exists('a')
 
     def test_flush(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
         adapter.flush()
 
         item = adapter.get('a')

--- a/tests/caching/adapters/test_memcached_adapter.py
+++ b/tests/caching/adapters/test_memcached_adapter.py
@@ -1,8 +1,11 @@
 # pylint: disable=no-self-use,redefined-outer-name
 
-import pytest
+import time
+from types import MethodType
 
-from mock import patch
+import pytest
+from mock import patch, Mock
+from pymemcache.client.base import Client
 from pymemcache.test.utils import MockMemcacheClient
 
 from flashback.caching.adapters import MemcachedAdapter
@@ -11,81 +14,168 @@ from flashback.caching.adapters import MemcachedAdapter
 @pytest.fixture
 @patch('flashback.caching.adapters.memcached_adapter.Client', MockMemcacheClient)
 def adapter():
+    MockMemcacheClient._check_integer = Client._check_integer
+
     return MemcachedAdapter()
 
 
 class TestMemcachedAdapter:
     def test_set(self, adapter):
-        assert adapter.set('a', 1)
+        assert adapter.set('a', '1', -1)
 
     def test_batch_set(self, adapter):
-        assert adapter.batch_set(['a', 'b', 'c'], [1, 2, 3])
+        def mocked_misc_cmd(self, commands, name, noreply):
+            results = []
+            for command in commands:
+                prefix, value = command.splitlines()
+                _, key, flags, expire, length = prefix.split(b' ')
+
+                self.set(key, value, int(expire))
+
+                results.append(b'STORED')
+
+            return results
+        adapter.store._misc_cmd = MethodType(mocked_misc_cmd, adapter.store)
+
+        assert adapter.batch_set(['a', 'b', 'c'], ['1', '2', '3'], [-1, -1, -1])
 
     def test_get(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         item = adapter.get('a')
 
-        assert item == 1
+        assert item == b'1'
 
-    def test_get_empty(self, adapter):
-        item = adapter.get('z')
+    def test_get_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        item = adapter.get('a')
 
         assert item is None
 
     def test_batch_get(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        def mocked_misc_cmd(self, commands, name, noreply):
+            results = []
+            for command in commands:
+                prefix, value = command.splitlines()
+                _, key, flags, expire, length = prefix.split(b' ')
+
+                self.set(key, value, int(expire))
+
+                results.append(b'STORED')
+
+            return results
+        adapter.store._misc_cmd = MethodType(mocked_misc_cmd, adapter.store)
+
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [1, 2]
+        assert items == [b'1', b'2']
 
-    def test_batch_get_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_get_expired(self, adapter):
+        def mocked_misc_cmd(self, commands, name, noreply):
+            results = []
+            for command in commands:
+                prefix, value = command.splitlines()
+                _, key, flags, expire, length = prefix.split(b' ')
 
-        items = adapter.batch_get(['a', 'z'])
+                self.set(key, value, int(expire))
+
+                results.append(b'STORED')
+
+            return results
+        adapter.store._misc_cmd = MethodType(mocked_misc_cmd, adapter.store)
+
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
+
+        time.sleep(1)
+
+        items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [1, None]
-
-    def test_batch_get_empty(self, adapter):
-        items = adapter.batch_get(['a', 'z'])
-
-        assert len(items) == 2
-        assert items == [None, None]
+        assert items == [b'1', None]
 
     def test_delete(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.delete('a')
 
-    def test_delete_empty(self, adapter):
-        assert not adapter.delete('z')
+    def test_delete_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert adapter.delete('a')
 
     def test_batch_delete(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        def mocked_misc_cmd(self, commands, name, noreply):
+            results = []
+            for command in commands:
+                prefix, *value = command.splitlines()
+                if prefix.startswith(b'set '):
+                    _, key, flags, expire, length = prefix.split(b' ')
+
+                    self.set(key, value[0], int(expire))
+
+                    results.append(b'STORED')
+                elif prefix.startswith(b'delete '):
+                    _, key = prefix.split(b' ')
+
+                    self.delete(key)
+
+                    results.append(b'DELETED')
+
+            return results
+        adapter.store._misc_cmd = MethodType(mocked_misc_cmd, adapter.store)
+
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         assert adapter.batch_delete(['a', 'b'])
 
-    def test_batch_delete_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_delete_expired(self, adapter):
+        def mocked_misc_cmd(self, commands, name, noreply):
+            results = []
+            for command in commands:
+                prefix, *value = command.splitlines()
+                if prefix.startswith(b'set '):
+                    _, key, flags, expire, length = prefix.split(b' ')
 
-        assert not adapter.batch_delete(['a', 'z'])
+                    self.set(key, value[0], int(expire))
 
-    def test_batch_delete_empty(self, adapter):
+                    results.append(b'STORED')
+                elif prefix.startswith(b'delete '):
+                    _, key = prefix.split(b' ')
+
+                    results.append(b'DELETED' if self.delete(key, False) else b'NOT_FOUND')
+
+            return results
+        adapter.store._misc_cmd = MethodType(mocked_misc_cmd, adapter.store)
+
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
+
+        time.sleep(1)
+
+        assert adapter.batch_get(['a', 'b']) == [b'1', None]
         assert not adapter.batch_delete(['a', 'b'])
 
     def test_exists(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.exists('a')
 
-    def test_exists_empty(self, adapter):
-        assert not adapter.exists('z')
+    def test_exists_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert not adapter.exists('a')
 
     def test_flush(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
         adapter.flush()
 
         item = adapter.get('a')

--- a/tests/caching/adapters/test_memory_adapter.py
+++ b/tests/caching/adapters/test_memory_adapter.py
@@ -1,5 +1,7 @@
 # pylint: disable=no-self-use,redefined-outer-name
 
+import time
+
 import pytest
 
 from flashback.caching.adapters import MemoryAdapter
@@ -12,76 +14,83 @@ def adapter():
 
 class TestMemoryAdapter:
     def test_set(self, adapter):
-        assert adapter.set('a', 1)
+        assert adapter.set('a', '1', -1)
 
     def test_batch_set(self, adapter):
-        assert adapter.batch_set(['a', 'b', 'c'], [1, 2, 3])
+        assert adapter.batch_set(['a', 'b', 'c'], ['1', '1', '1'], [-1, -1, -1])
 
     def test_get(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         item = adapter.get('a')
 
-        assert item == 1
+        assert item == '1'
 
-    def test_get_empty(self, adapter):
-        item = adapter.get('z')
+    def test_get_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        item = adapter.get('a')
 
         assert item is None
 
     def test_batch_get(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [1, 2]
+        assert items == ['1', '2']
 
-    def test_batch_get_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_get_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        items = adapter.batch_get(['a', 'z'])
+        time.sleep(1)
 
-        assert len(items) == 2
-        assert items == [1, None]
-
-    def test_batch_get_empty(self, adapter):
-        items = adapter.batch_get(['a', 'z'])
+        items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
-        assert items == [None, None]
+        assert items == ['1', None]
 
     def test_delete(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.delete('a')
 
-    def test_delete_empty(self, adapter):
-        assert not adapter.delete('z')
+    def test_delete_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert not adapter.delete('a')
 
     def test_batch_delete(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         assert adapter.batch_delete(['a', 'b'])
 
-    def test_batch_delete_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_delete_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        assert not adapter.batch_delete(['a', 'z'])
+        time.sleep(1)
 
-    def test_batch_delete_empty(self, adapter):
         assert not adapter.batch_delete(['a', 'b'])
 
     def test_exists(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.exists('a')
 
-    def test_exists_empty(self, adapter):
-        assert not adapter.exists('z')
+    def test_exists_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+
+        assert not adapter.exists('a')
 
     def test_flush(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
         adapter.flush()
 
         item = adapter.get('a')

--- a/tests/caching/adapters/test_redis_adapter.py
+++ b/tests/caching/adapters/test_redis_adapter.py
@@ -1,5 +1,7 @@
 # pylint: disable=no-self-use,redefined-outer-name
 
+import time
+
 import pytest
 
 from mock import patch
@@ -16,76 +18,88 @@ def adapter():
 
 class TestRedisAdapter:
     def test_set(self, adapter):
-        assert adapter.set('a', 1)
+        assert adapter.set('a', '1', -1)
 
     def test_batch_set(self, adapter):
-        assert adapter.batch_set(['a', 'b', 'c'], [1, 2, 3])
+        assert adapter.batch_set(['a', 'b', 'c'], ['1', '2', '3'], [-1, -1, -1])
 
     def test_get(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         item = adapter.get('a')
 
         assert item == '1'
 
-    def test_get_empty(self, adapter):
-        item = adapter.get('z')
+    def test_get_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+        adapter.store.do_expire()
+
+        item = adapter.get('a')
 
         assert item is None
 
     def test_batch_get(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
         assert items == ['1', '2']
 
-    def test_batch_get_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_get_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        items = adapter.batch_get(['a', 'z'])
+        time.sleep(1)
+        adapter.store.do_expire()
+
+        items = adapter.batch_get(['a', 'b'])
 
         assert len(items) == 2
         assert items == ['1', None]
 
-    def test_batch_get_empty(self, adapter):
-        items = adapter.batch_get(['a', 'z'])
-
-        assert len(items) == 2
-        assert items == [None, None]
-
     def test_delete(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.delete('a')
 
-    def test_delete_empty(self, adapter):
-        assert not adapter.delete('z')
+    def test_delete_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+        adapter.store.do_expire()
+
+        assert not adapter.delete('a')
 
     def test_batch_delete(self, adapter):
-        adapter.batch_set(['a', 'b'], [1, 2])
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, -1])
 
         assert adapter.batch_delete(['a', 'b'])
 
-    def test_batch_delete_partial(self, adapter):
-        adapter.set('a', 1)
+    def test_batch_delete_expired(self, adapter):
+        adapter.batch_set(['a', 'b'], ['1', '2'], [-1, 1])
 
-        assert not adapter.batch_delete(['a', 'z'])
+        time.sleep(1)
+        adapter.store.do_expire()
 
-    def test_batch_delete_empty(self, adapter):
         assert not adapter.batch_delete(['a', 'b'])
 
     def test_exists(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
 
         assert adapter.exists('a')
 
-    def test_exists_empty(self, adapter):
-        assert not adapter.exists('z')
+    def test_exists_expired(self, adapter):
+        adapter.set('a', '1', 1)
+
+        time.sleep(1)
+        adapter.store.do_expire()
+
+        assert not adapter.exists('a')
 
     def test_flush(self, adapter):
-        adapter.set('a', 1)
+        adapter.set('a', '1', -1)
         adapter.flush()
 
         item = adapter.get('a')

--- a/tests/caching/test_cache.py
+++ b/tests/caching/test_cache.py
@@ -41,8 +41,11 @@ class TestCache:
         with pytest.raises(NotImplementedError):
             Cache(adapter='dummy')
 
+    def test_set_ttl(self, cache):
+        assert cache.set('a', 'a', 1)
+
     def test_set_str(self, cache):
-        assert cache.set('a', 'abc')
+        assert cache.set('a', 'a')
 
     def test_set_int(self, cache):
         assert cache.set('a', 1)
@@ -61,6 +64,9 @@ class TestCache:
 
     def test_batch_set(self, cache):
         assert cache.batch_set(['a', 'b'], [1, 2])
+
+    def test_batch_set_ttls(self, cache):
+        assert cache.batch_set(['a', 'b'], [1, 2], [1, 1])
 
     def test_batch_set_invalid(self, cache):
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Description

- Added support for ttl to Cache:
    - A value of -1 do not set an expiry
- Added support for ttl to RedisAdapter:
    - Migrated to a pipeline execution for `batch_set()` because Redis' `MSET` does not have an `MSETEX` counterpart like `SET` does.
- Added support for ttl to MemoryAdapter:
    - Implemented a expiry-keeping mechanism within MemoryAdapter, that locks the store when accessed, and flushes expired keys before every read operation.
- Added support for ttl to DiskAdapter:
    - Implemented an eviction of expired keys before every read operation
- Added support for ttl to MemcachedAdapter:
    - Re-implemented `batch_set()` and `batch_delete()` to make them more "atomic" (See comments)
- Closes #3 

### Checklist

- [x] PR is reviewable (has less than 1000 changes)
- [x] Tests are up to date
- [x] Code is linted
- [x] Documentation is up to date
- [x] Dependencies are up to date
- [x] CHANGELOG.md is up to date
